### PR TITLE
made it so you can put raw javascript variables in the options

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,29 @@ helper Riiif::OpenseadragonHelper
 Then in your view you can do this:
 ```erb
     <%=javascript_include_tag "openseadragon.js" %>
-    <%= openseadragon_viewer(@image.id, html: {style: 'width: 800px; height: 600px;'}) %>
+    <%= openseadragon_collection_viewer [@image.id, @image], id: 'openseadragon', collectionRows: 1 %>
 ```
 
+Sometimes you might want to put javascript variables in for the options. To stop certain keys from stringifying their values, use options_with_raw_js like this:
+
+```erb
+    <%=javascript_include_tag "openseadragon.js" %>
+    <%= openseadragon_collection_viewer [@image.id], element: "document.getElementById('openseadragon')", options_with_raw_js: [:element] %>
+```
+
+### Using a default image
+
+If there is a request for an id that doesn't exist, a 404 will be returned. You can optionally return an image with this 404 by setting this in your initializer:
+
+```ruby
+Riiif::not_found_image = 'path/to/image.png'
+```
+
+You can do this to create a default Riiif::Image to use (useful for passing "missing" images to openseadragon_collection_viewer):
+
+```ruby
+Riiif::Image.new('no_image', Riiif::File.new(Riiif.not_found_image))
+```
 
 ## Running the tests
 First, build the engine

--- a/spec/helpers/openseadragon_helper_spec.rb
+++ b/spec/helpers/openseadragon_helper_spec.rb
@@ -8,37 +8,36 @@ describe Riiif::OpenseadragonHelper do
 //<![CDATA[
         function initOpenSeadragon() {
           OpenSeadragon({
-  "id": "openseadragon1",
-  "prefixUrl": "/assets/openseadragon/",
-  "tileSources": [
-    {
-      "identifier": "world",
-      "width": 800,
-      "height": 400,
-      "scale_factors": [
-        1,
-        2,
-        3,
-        4,
-        5
-      ],
-      "formats": [
-        "jpg",
-        "png"
-      ],
-      "qualities": [
-        "native",
-        "bitonal",
-        "grey",
-        "color"
-      ],
-      "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level3",
-      "tile_width": 1024,
-      "tile_height": 1024,
-      "image_host": "/foo"
-    }
-  ]
-});
+"id": "openseadragon1",
+"prefixUrl": "/assets/openseadragon/",
+"tileSources": [
+  {
+    "identifier": "world",
+    "width": 800,
+    "height": 400,
+    "scale_factors": [
+      1,
+      2,
+      3,
+      4,
+      5
+    ],
+    "formats": [
+      "jpg",
+      "png"
+    ],
+    "qualities": [
+      "native",
+      "bitonal",
+      "grey",
+      "color"
+    ],
+    "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level3",
+    "tile_width": 1024,
+    "tile_height": 1024,
+    "image_host": "/foo"
+  }
+]});
         }
         window.onload = initOpenSeadragon;
         document.addEventListener("page:load", initOpenSeadragon); // Initialize when using turbolinks
@@ -49,74 +48,80 @@ describe Riiif::OpenseadragonHelper do
 
   it "should not crash when there's no tileSources" do
     openseadragon_collection_viewer(['world', 'irises'], {extraOption: :some_stuff})
+    openseadragon_collection_viewer(['world', 'irises'],
+                                    {extraOption: :some_stuff,
+                                     rawOption: "(1 + 1)",
+                                     options_with_raw_js: [:rawOption]})
   end
 
   it "should draw the collection viewer" do
     out = openseadragon_collection_viewer(['world', 'irises'],
                                           {tileSources: [{profile: :foo}, {profile: :bar}],
-                                           extraOption: :some_stuff})
+                                           extraOption: :some_stuff,
+                                           rawOption: "(1 + 1)",
+                                           options_with_raw_js: [:rawOption]})
     out.should == '<div id="openseadragon1"></div><script>
 //<![CDATA[
         function initOpenSeadragon() {
           OpenSeadragon({
-  "id": "openseadragon1",
-  "prefixUrl": "/assets/openseadragon/",
-  "tileSources": [
-    {
-      "identifier": "world",
-      "width": 800,
-      "height": 400,
-      "scale_factors": [
-        1,
-        2,
-        3,
-        4,
-        5
-      ],
-      "formats": [
-        "jpg",
-        "png"
-      ],
-      "qualities": [
-        "native",
-        "bitonal",
-        "grey",
-        "color"
-      ],
-      "profile": "foo",
-      "tile_width": 1024,
-      "tile_height": 1024,
-      "image_host": "/image-service"
-    },
-    {
-      "identifier": "irises",
-      "width": 4264,
-      "height": 3282,
-      "scale_factors": [
-        1,
-        2,
-        3,
-        4,
-        5
-      ],
-      "formats": [
-        "jpg",
-        "png"
-      ],
-      "qualities": [
-        "native",
-        "bitonal",
-        "grey",
-        "color"
-      ],
-      "profile": "bar",
-      "tile_width": 1024,
-      "tile_height": 1024,
-      "image_host": "/image-service"
-    }
-  ],
-  "extraOption": "some_stuff"
-});
+"id": "openseadragon1",
+"prefixUrl": "/assets/openseadragon/",
+"tileSources": [
+  {
+    "identifier": "world",
+    "width": 800,
+    "height": 400,
+    "scale_factors": [
+      1,
+      2,
+      3,
+      4,
+      5
+    ],
+    "formats": [
+      "jpg",
+      "png"
+    ],
+    "qualities": [
+      "native",
+      "bitonal",
+      "grey",
+      "color"
+    ],
+    "profile": "foo",
+    "tile_width": 1024,
+    "tile_height": 1024,
+    "image_host": "/image-service"
+  },
+  {
+    "identifier": "irises",
+    "width": 4264,
+    "height": 3282,
+    "scale_factors": [
+      1,
+      2,
+      3,
+      4,
+      5
+    ],
+    "formats": [
+      "jpg",
+      "png"
+    ],
+    "qualities": [
+      "native",
+      "bitonal",
+      "grey",
+      "color"
+    ],
+    "profile": "bar",
+    "tile_width": 1024,
+    "tile_height": 1024,
+    "image_host": "/image-service"
+  }
+],
+"extraOption": "some_stuff",
+rawOption: (1 + 1)});
         }
         window.onload = initOpenSeadragon;
         document.addEventListener("page:load", initOpenSeadragon); // Initialize when using turbolinks


### PR DESCRIPTION
Turbolinks and seadragon don't play nicely together. When going to new pages, the seadragon view will be duplicated on the same node and two of them will appear (and more as you go to subsequent pages). I thought maybe creating a dom-node and then passing it into the seadragon 'element' option would fix this but it didn't.

It does seem useful to be able to pass raw javascript into the options though (say, if you want to use an existing js variable or something). I see two ways of doing this:

Pass in every option as raw javascript (this feels cumbersome, with lots of "'...'" stuff):

``` ruby
openseadragon_collection_viewer [@image.id], id: "'some_id'",
                                             other_option: "some_js_variable"
```

Or, specify which options are raw javascript:

``` ruby
openseadragon_collection_viewer [@image.id], id: "some_id",
                                             other_option: "some_js_variable",
                                             options_with_raw_js: [:id]
```

This PR implements the latter. If you don't really like this solution we can just let the branch die. I'm kind of split on it myself and would like to hear others' thoughts.
