### PR TITLE
Update for rails 5 deprecation warnings

### DIFF
--- a/app/controllers/riiif/images_controller.rb
+++ b/app/controllers/riiif/images_controller.rb
@@ -20,7 +20,7 @@ module Riiif
 
       image = not_found_image unless status == :ok
 
-      data = image.render(params.permit(:region, :size, :rotation, :quality, :format))
+      data = image.render(image_request_params)
       headers['Access-Control-Allow-Origin'] = '*'
       send_data data,
                 status: status,
@@ -54,6 +54,12 @@ module Riiif
 
       def image_id
         params[:id]
+      end
+
+      ##
+      # @return [ActiveSupport::HashWithIndifferentAccess]
+      def image_request_params
+        params.permit(:region, :size, :rotation, :quality, :format).to_h
       end
 
       def authorization_service

--- a/app/controllers/riiif/images_controller.rb
+++ b/app/controllers/riiif/images_controller.rb
@@ -1,6 +1,6 @@
 module Riiif
   class ImagesController < ::ApplicationController
-    before_filter :link_header, only: [:show, :info]
+    before_action :link_header, only: [:show, :info]
 
     rescue_from Riiif::InvalidAttributeError do
       render nothing: true, status: 400

--- a/app/controllers/riiif/images_controller.rb
+++ b/app/controllers/riiif/images_controller.rb
@@ -3,7 +3,7 @@ module Riiif
     before_action :link_header, only: [:show, :info]
 
     rescue_from Riiif::InvalidAttributeError do
-      render nothing: true, status: 400
+      head 400
     end
 
     def show

--- a/app/models/riiif/image.rb
+++ b/app/models/riiif/image.rb
@@ -32,6 +32,8 @@ module Riiif
       @image ||= file_resolver.find(id)
     end
 
+    ##
+    # @param [ActiveSupport::HashWithIndifferentAccess] args
     def render(args)
       options = decode_options!(args)
       Rails.cache.fetch(Image.cache_key(id, options), compress: true, expires_in: Image.expires_in) do
@@ -58,8 +60,9 @@ module Riiif
 
     private
 
-      def decode_options!(args)
-        options = args.with_indifferent_access
+      ##
+      # @param [ActiveSupport::HashWithIndifferentAccess] options
+      def decode_options!(options)
         raise ArgumentError, 'You must provide a format' unless options[:format]
         options[:crop] = decode_region(options.delete(:region))
         options[:size] = decode_size(options.delete(:size))

--- a/spec/controllers/riiif/images_controller_spec.rb
+++ b/spec/controllers/riiif/images_controller_spec.rb
@@ -107,7 +107,7 @@ describe Riiif::ImagesController do
       expect(response).to be_successful
       json = JSON.parse(response.body)
       expect(json).to eq '@context' => 'http://iiif.io/api/image/2/context.json',
-                         '@id' => 'http://test.host/images/abcd1234',
+                         '@id' => 'http://test.host/abcd1234',
                          'width' => 6000,
                          'height' => 4000,
                          'profile' => ['http://iiif.io/api/image/2/level1.json', 'formats' => %w(jpg png)],

--- a/spec/controllers/riiif/images_controller_spec.rb
+++ b/spec/controllers/riiif/images_controller_spec.rb
@@ -12,8 +12,8 @@ describe Riiif::ImagesController do
       expect(image).to receive(:render).with('region' => 'full', 'size' => 'full',
                                              'rotation' => '0', 'quality' => 'default',
                                              'format' => 'jpg').and_return('IMAGEDATA')
-      get :show, id: 'abcd1234', action: 'show', region: 'full', size: 'full',
-                 rotation: '0', quality: 'default', format: 'jpg'
+      get :show, params: { id: 'abcd1234', action: 'show', region: 'full', size: 'full',
+                           rotation: '0', quality: 'default', format: 'jpg' }
       expect(response).to be_successful
       expect(response.body).to eq 'IMAGEDATA'
       expect(response.headers['Link']).to eq '<http://iiif.io/api/image/2/level1.json>;rel="profile"'
@@ -28,8 +28,8 @@ describe Riiif::ImagesController do
         allow(controller).to receive(:not_found_image).and_return(not_found_image)
       end
       it 'renders 401' do
-        get :show, id: 'abcd1234', action: 'show', region: 'full', size: 'full',
-                   rotation: '0', quality: 'default', format: 'jpg'
+        get :show, params: { id: 'abcd1234', action: 'show', region: 'full', size: 'full',
+                             rotation: '0', quality: 'default', format: 'jpg' }
         expect(response.body).to eq 'test data'
         expect(response.code).to eq '401'
       end
@@ -40,8 +40,8 @@ describe Riiif::ImagesController do
         image = double('an image')
         allow(image).to receive(:render).and_raise Riiif::InvalidAttributeError
         allow(Riiif::Image).to receive(:new).with('abcd1234').and_return(image)
-        get :show, id: 'abcd1234', action: 'show', region: '`szoW0', size: 'full',
-                   rotation: '0', quality: 'default', format: 'jpg'
+        get :show, params: { id: 'abcd1234', action: 'show', region: '`szoW0', size: 'full',
+                             rotation: '0', quality: 'default', format: 'jpg' }
         expect(response.code).to eq '400'
       end
     end
@@ -50,8 +50,8 @@ describe Riiif::ImagesController do
       it "errors when a default image isn't sent" do
         expect(Riiif::Image).to receive(:new).with('bad_id').and_raise(OpenURI::HTTPError.new('fail', StringIO.new))
         expect do
-          get :show, id: 'bad_id', action: 'show', region: 'full', size: 'full',
-                     rotation: '0', quality: 'default', format: 'jpg'
+          get :show, params: { id: 'bad_id', action: 'show', region: 'full', size: 'full',
+                               rotation: '0', quality: 'default', format: 'jpg' }
         end.to raise_error(StandardError)
       end
 
@@ -73,8 +73,8 @@ describe Riiif::ImagesController do
                                                            'rotation' => '0', 'quality' => 'default',
                                                            'format' => 'jpg').and_return('default-image-data')
 
-          get :show, id: 'bad_id', action: 'show', region: 'full', size: 'full',
-                     rotation: '0', quality: 'default', format: 'jpg'
+          get :show, params: { id: 'bad_id', action: 'show', region: 'full', size: 'full',
+                               rotation: '0', quality: 'default', format: 'jpg' }
           expect(response).to be_not_found
           expect(response.body).to eq 'default-image-data'
         end
@@ -89,8 +89,8 @@ describe Riiif::ImagesController do
                                                            'rotation' => '0', 'quality' => 'default',
                                                            'format' => 'jpg').and_return('default-image-data')
 
-          get :show, id: 'bad_id', action: 'show', region: 'full', size: 'full',
-                     rotation: '0', quality: 'default', format: 'jpg'
+          get :show, params: { id: 'bad_id', action: 'show', region: 'full', size: 'full',
+                               rotation: '0', quality: 'default', format: 'jpg' }
           expect(response).to be_not_found
           expect(response.body).to eq 'default-image-data'
         end
@@ -103,7 +103,7 @@ describe Riiif::ImagesController do
       image = double
       expect(Riiif::Image).to receive(:new).with('abcd1234').and_return(image)
       expect(image).to receive(:info).and_return(width: 6000, height: 4000)
-      get :info, id: 'abcd1234', format: 'json'
+      get :info, params: { id: 'abcd1234', format: 'json' }
       expect(response).to be_successful
       json = JSON.parse(response.body)
       expect(json).to eq '@context' => 'http://iiif.io/api/image/2/context.json',
@@ -123,7 +123,7 @@ describe Riiif::ImagesController do
         allow(controller).to receive(:authorization_service).and_return(auth)
       end
       it 'renders 401' do
-        get :info, id: 'abcd1234', format: 'json'
+        get :info, params: { id: 'abcd1234', format: 'json' }
         expect(response.body).to eq '{"error":"unauthorized"}'
         expect(response.code).to eq '401'
       end


### PR DESCRIPTION
There may be some controversial things here:

ba138f4 - this seemed to be the sanest way of dealing with converting `ActionController::Parameters` to a hash-like object. Because other classes depend on that hash-like contract, doing the conversion here seemed most appropriate http://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-to_h

c2a49b7 - I couldn't seem to figure out why now that controller specs don't understand the path using a mounted engine and `request.original_url` /shrug ? help?