### PR TITLE
Allow configurable image cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,17 @@ And then execute:
 Or install it yourself as:
 
     $ gem install riiif
-    
+
 ## Configure
 
 ### Images on the servers file system.
 
-By default Riiif is set to load images from the filesystem using the Riiif::FileSystemFileResolver. 
+By default Riiif is set to load images from the filesystem using the Riiif::FileSystemFileResolver.
 You can configure how this resolver finds the files by setting this property:
 ```
     Riiif::Image.file_resolver.base_path = '/opt/repository/images/'
 ```
-When the Id passed in is "foo_image", then it will look for an image file using this glob: 
+When the Id passed in is "foo_image", then it will look for an image file using this glob:
 ```
 /opt/repository/images/foo_image.{png,jpg,tiff,jp,jp2}
 ```
@@ -65,7 +65,7 @@ By default the cache is located in `tmp/network_files`. You can set the cache pa
 
 ## Usage
 
-Add the routes to your application by inserting the following line into `config/routes.rb` 
+Add the routes to your application by inserting the following line into `config/routes.rb`
 ```
   mount Riiif::Engine => '/image-service', as: 'riiif'
 ```
@@ -103,7 +103,7 @@ Riiif::Image.new('no_image', Riiif::File.new(Riiif.not_found_image))
 
 ## Authorization
 
-The controller will call an authorization service with the controller context.  This service must have a method `can?(action, image)` which returns a boolean. The default service is the `RIIIF::NilAuthrorizationService` which permits all requests. 
+The controller will call an authorization service with the controller context.  This service must have a method `can?(action, image)` which returns a boolean. The default service is the `RIIIF::NilAuthrorizationService` which permits all requests.
 
 In this example we've dissallowed all requests:
 
@@ -129,14 +129,14 @@ Create an initializer like this in `config/initializers/riiif_initializer.rb`
 Riiif::Image.file_resolver = Riiif::HTTPFileResolver.new
 
 # This tells RIIIF how to resolve the identifier to a URI in Fedora
-Riiif::Image.file_resolver.id_to_uri = lambda do |id| 
+Riiif::Image.file_resolver.id_to_uri = lambda do |id|
   ActiveFedora::Base.id_to_uri(CGI.unescape(id)).tap do |url|
     logger.info "Riiif resolved #{id} to #{url}"
   end
 end
 
 # In order to return the info.json endpoint, we have to have the full height and width of
-# each image. If you are using hydra-file_characterization, you have the height & width 
+# each image. If you are using hydra-file_characterization, you have the height & width
 # cached in Solr. The following block directs the info_service to return those values:
 Riiif::Image.info_service = lambda do |id, file|
   # id will look like a path to a pcdm:file
@@ -155,6 +155,11 @@ def logger
   Rails.logger
 end
 
+# Note that this is translated to an `expires` argument to the
+# ActiveSupport::Cache::Store in use, by default the host application's
+# Rails.cache. Some cache stores may not automatically purge expired content,
+# such as the default FileStore.
+# http://guides.rubyonrails.org/caching_with_rails.html#cache-stores
 Riiif::Engine.config.cache_duration_in_days = 30
 ```
 #### Special note for Passenger and Apache users

--- a/app/models/riiif/image.rb
+++ b/app/models/riiif/image.rb
@@ -1,9 +1,10 @@
 require 'digest/md5'
 module Riiif
   class Image
-    class_attribute :file_resolver, :info_service, :authorization_service
+    class_attribute :file_resolver, :info_service, :authorization_service, :cache
     self.file_resolver = FileSystemFileResolver.new
     self.authorization_service = NilAuthorizationService
+    self.cache = Rails.cache
 
     # this is the default info service
     # returns a hash with the original image dimensions.
@@ -11,7 +12,7 @@ module Riiif
     # example:
     #   {:height=>390, :width=>600}
     self.info_service = lambda do |id, image|
-      Rails.cache.fetch(cache_key(id, info: true), compress: true, expires_in: expires_in) do
+      cache.fetch(cache_key(id, info: true), compress: true, expires_in: expires_in) do
         image.info
       end
     end
@@ -35,7 +36,7 @@ module Riiif
     # @param [ActiveSupport::HashWithIndifferentAccess] args
     def render(args)
       options = decode_options!(args)
-      Rails.cache.fetch(Image.cache_key(id, options), compress: true, expires_in: Image.expires_in) do
+      cache.fetch(Image.cache_key(id, options), compress: true, expires_in: Image.expires_in) do
         image.extract(options)
       end
     end

--- a/spec/models/riiif/image_spec.rb
+++ b/spec/models/riiif/image_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Riiif::Image do
-  before { Rails.cache.clear }
+  before { Riiif::Image.cache.clear }
   let(:filename) { File.expand_path('spec/samples/world.jp2') }
   subject { described_class.new('world') }
   describe 'happy path' do
@@ -53,7 +53,7 @@ RSpec.describe Riiif::Image do
 
     context 'when the rendered image is in the cache' do
       subject { described_class.new('Cave_26,_Ajanta') }
-      before { allow(Rails.cache).to receive(:fetch).and_return('expected') }
+      before { allow(Riiif::Image.cache).to receive(:fetch).and_return('expected') }
 
       it 'does not fetch the file' do
         expect(described_class.file_resolver).not_to receive(:find)


### PR DESCRIPTION
Still defaults to `Rails.cache`, but can be set to
any ActiveSupport::Cache::Store

Developer may want to use a different cache for images
than app-wide Rails.cache. Perhaps a slower but less expensive
storage, or just a different one to keep images from pushing
general app cache content out of cache, or vice versa.