### PR TITLE
use prefix on cache key to avoid collisions

### DIFF
--- a/app/models/riiif/image.rb
+++ b/app/models/riiif/image.rb
@@ -54,8 +54,9 @@ module Riiif
 
       def cache_key(id, options)
         str = options.to_h.merge(id: id).delete_if { |_, v| v.nil? }.to_s
-        # Use a MD5 digest to ensure the keys aren't too long.
-        Digest::MD5.hexdigest(str)
+        # Use a MD5 digest to ensure the keys aren't too long, and a prefix
+        # to avoid collisions with other components in shared cache.
+        'riiif:' + Digest::MD5.hexdigest(str)
       end
     end
 


### PR DESCRIPTION
With default Rails.cache, we're sharing a cache.
While there _probably_ isn't something else storing in cache
with key that's MD5 of a hash of arguments... why take the
chance of mystery hard to reproduce bug, just prefix to avoid
collisions.