### PR TITLE
spec content-type returned from #show

### DIFF
--- a/spec/controllers/riiif/images_controller_spec.rb
+++ b/spec/controllers/riiif/images_controller_spec.rb
@@ -16,6 +16,7 @@ describe Riiif::ImagesController do
                            rotation: '0', quality: 'default', format: 'jpg' }
       expect(response).to be_successful
       expect(response.body).to eq 'IMAGEDATA'
+      expect(response.headers['Content-Type']).to eq 'image/jpeg'
       expect(response.headers['Link']).to eq '<http://iiif.io/api/image/2/level1.json>;rel="profile"'
       expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
       expect(response.headers['Cache-Control']).to eq 'max-age=31557600, private'


### PR DESCRIPTION
Code was already doing the right thing, good to have it in a spec,
as it's fairly important behavior.