### PR TITLE
The ImageNotFoundError should take a message as the first argument

### DIFF
--- a/lib/riiif.rb
+++ b/lib/riiif.rb
@@ -12,12 +12,7 @@ module Riiif
 
   class Error < RuntimeError; end
   class InvalidAttributeError < Error; end
-  class ImageNotFoundError < Error
-    attr_reader :original_exception
-    def initialize(orig = nil)
-      @original_exception = orig
-    end
-  end
+  class ImageNotFoundError < Error; end
   # This error is raised when Riiif can't convert an image
   class ConversionError < Error; end
 

--- a/lib/riiif/http_file_resolver.rb
+++ b/lib/riiif/http_file_resolver.rb
@@ -69,7 +69,7 @@ module Riiif
                   end
                 end
               rescue OpenURI::HTTPError => e
-                raise ImageNotFoundError, e
+                raise ImageNotFoundError, e.message
               end
             end
           end

--- a/spec/models/riiif/http_file_resolver_spec.rb
+++ b/spec/models/riiif/http_file_resolver_spec.rb
@@ -17,7 +17,7 @@ describe Riiif::HTTPFileResolver do
     rescue Riiif::ImageNotFoundError => e
     end
     expect(e).to be_a Riiif::ImageNotFoundError
-    expect(e.original_exception).to be_an OpenURI::HTTPError
+    expect(e.message).to eq 'failure'
   end
 
   context 'when basic authentication credentials are set' do


### PR DESCRIPTION
This allows this message to be useful:
https://github.com/curationexperts/riiif/blob/0c0e59373df5ef17cd958adb92ef567b8d72a703/app/controllers/riiif/images_controller.rb#L103