### PR TITLE
Restore ImageInformation#[] method

### DIFF
--- a/app/models/riiif/image_information.rb
+++ b/app/models/riiif/image_information.rb
@@ -1,6 +1,10 @@
+require 'deprecation'
+
 module Riiif
   # This is the result of calling the Riiif.image_info service. It stores the height & width
   class ImageInformation
+    extend Deprecation
+
     def initialize(width, height)
       @width = width
       @height = height
@@ -11,6 +15,13 @@ module Riiif
     def to_h
       { width: width, height: height }
     end
+
+    def [](key)
+      to_h[key]
+    end
+    deprecation_deprecate :[] => 'Riiif::ImageInformation#[] has been deprecated ' \
+      'and will be removed in version 2.0. Use Riiif::ImageInformation#to_h and ' \
+      'call #[] on that result OR consider using #height and #width directly.'
 
     # Image information is only valid if height and width are present.
     # If an image info service doesn't have the value yet (not characterized perhaps?)

--- a/riiif.gemspec
+++ b/riiif.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'railties', '>= 4.2', '<6'
+  spec.add_dependency 'deprecation', '>= 1.0.0'
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'engine_cart', '~> 0.8'

--- a/spec/models/riiif/image_information_spec.rb
+++ b/spec/models/riiif/image_information_spec.rb
@@ -16,4 +16,12 @@ RSpec.describe Riiif::ImageInformation do
       it { is_expected.to be false }
     end
   end
+
+  describe '#[]' do
+    subject { info[:width] }
+    let(:info) { described_class.new(100, 200) }
+    before { allow(Deprecation).to receive(:warn) }
+
+    it { is_expected.to eq 100 }
+  end
 end


### PR DESCRIPTION
The previous release accidentally removed this API method.

See:
https://github.com/curationexperts/riiif/pull/76#issuecomment-312053599