### PR TITLE
Add '[0]' to select the first image frame in Riiif::ImageMagickInfoExtractor

### DIFF
--- a/app/services/riiif/image_magick_info_extractor.rb
+++ b/app/services/riiif/image_magick_info_extractor.rb
@@ -6,7 +6,7 @@ module Riiif
     end
 
     def extract
-      height, width = Riiif::CommandRunner.execute("identify -format %hx%w #{@path}").split('x')
+      height, width = Riiif::CommandRunner.execute("identify -format %hx%w #{@path}[0]").split('x')
       { height: Integer(height), width: Integer(width) }
     end
   end

--- a/spec/models/riiif/image_spec.rb
+++ b/spec/models/riiif/image_spec.rb
@@ -75,14 +75,14 @@ RSpec.describe Riiif::Image do
 
       it 'handles percent geometry' do
         expect(Riiif::CommandRunner).to receive(:execute)
-          .with("identify -format %hx%w #{filename}").and_return('131x175')
+          .with("identify -format %hx%w #{filename}[0]").and_return('131x175')
         expect(Riiif::CommandRunner).to receive(:execute).with("convert -crop 80%x70+18+13 -strip #{filename} png:-")
         subject.render(region: 'pct:10,10,80,70', format: 'png')
       end
 
       it 'handles square geometry' do
         expect(Riiif::CommandRunner).to receive(:execute)
-          .with("identify -format %hx%w #{filename}").and_return('131x175')
+          .with("identify -format %hx%w #{filename}[0]").and_return('131x175')
         expect(Riiif::CommandRunner).to receive(:execute).with("convert -crop 131x131+22+0 -strip #{filename} png:-")
         subject.render(region: 'square', format: 'png')
       end


### PR DESCRIPTION
Fixes a bug where image files containing a sequence extract the wrong height and width values.

Sample image:
```shell
$ identify multi-image.tiff 
multi-image.tiff[0] TIFF 9653x6858 9653x6858+0+0 8-bit sRGB 189.459MiB 0.020u 0:00.029
multi-image.tiff[1] TIFF 160x114 160x114+0+0 8-bit sRGB 189.459MiB 0.000u 0:00.009
```

The current extract method combines the height of the first frame with the width of the second frame for the above image:
```ruby
Riiif::ImageMagickInfoExtractor.new('multi-image.tiff').extract
Riiif executed identify -format %hx%w multi-image.tiff (59.9ms)
=> {:height=>6858, :width=>9653114}
```

The `:width=>9653114` above is the bug. This PR adds `[0]` to the path in `extract` to grab the correct height and width values:

```ruby
Riiif::ImageMagickInfoExtractor.new('multi-image.tiff').extract
Riiif executed identify -format %hx%w multi-image.tiff[0] (69.9ms)
=> {:height=>6858, :width=>9653}
```
