### PR TITLE
Riiif::Image: don't inspect source image to create cache key

### DIFF
--- a/app/models/riiif/image.rb
+++ b/app/models/riiif/image.rb
@@ -52,9 +52,11 @@ module Riiif
     ##
     # @param [ActiveSupport::HashWithIndifferentAccess] args
     def render(args)
-      options = decode_options!(args)
-      cache.fetch(Image.cache_key(id, options), compress: true, expires_in: Image.expires_in) do
-        image.extract(options)
+      cache_opts = args.select { |a| %w(region size quality rotation format).include? a.to_s }
+      key = Image.cache_key(id, cache_opts)
+
+      cache.fetch(key, compress: true, expires_in: Image.expires_in) do
+        image.extract(decode_options!(args))
       end
     end
 

--- a/app/models/riiif/image.rb
+++ b/app/models/riiif/image.rb
@@ -73,7 +73,11 @@ module Riiif
       end
 
       def cache_key(id, options)
-        str = options.to_h.merge(id: id).delete_if { |_, v| v.nil? }.to_s
+        str = options.to_h.merge(id: id)
+                     .delete_if { |_, v| v.nil? }
+                     .sort_by { |k, _v| k.to_s }
+                     .to_s
+
         # Use a MD5 digest to ensure the keys aren't too long, and a prefix
         # to avoid collisions with other components in shared cache.
         'riiif:' + Digest::MD5.hexdigest(str)


### PR DESCRIPTION
Fixes GH-84.