### PR TITLE
Pass the base path when initializing a file resolver

### DIFF
--- a/app/models/riiif/image.rb
+++ b/app/models/riiif/image.rb
@@ -19,7 +19,7 @@ require_dependency 'riiif/size/imagemagick/width_decoder'
 module Riiif
   class Image
     class_attribute :file_resolver, :info_service, :authorization_service, :cache
-    self.file_resolver = FileSystemFileResolver.new
+    self.file_resolver = FileSystemFileResolver.new(base_path: File.join(Rails.root, 'tmp'))
     self.authorization_service = NilAuthorizationService
     self.cache = Rails.cache
 

--- a/lib/riiif/abstract_file_system_resolver.rb
+++ b/lib/riiif/abstract_file_system_resolver.rb
@@ -1,11 +1,22 @@
+require 'deprecation'
 module Riiif
   class AbstractFileSystemResolver
-    attr_accessor :root, :base_path
+    extend Deprecation
+    attr_accessor :base_path
 
-    def initialize
-      @root = ::File.expand_path(::File.join(::File.dirname(__FILE__), '../..'))
-      @base_path = ::File.join(root, 'spec/samples')
+    def initialize(base_path: nil)
+      @base_path = base_path || default_base_path
     end
+
+    def default_base_path
+      Deprecation.warn(self, 'Initializing a file resolver without setting the base path ' \
+      'is deprecated and will be removed in Riiif 2.0', caller(2))
+      @root ||= ::File.expand_path(::File.join(::File.dirname(__FILE__), '../..'))
+      ::File.join(@root, 'spec/samples')
+    end
+
+    attr_reader :root
+    deprecation_deprecate :root
 
     def find(id)
       Riiif::File.new(path(id))

--- a/spec/models/riiif/file_system_file_resolver_spec.rb
+++ b/spec/models/riiif/file_system_file_resolver_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 
 describe Riiif::FileSystemFileResolver do
-  let(:resolver) { described_class.new }
+  let(:root) { File.expand_path(::File.join(::File.dirname(__FILE__), '../../..')) }
+  let(:base_path) { ::File.join(root, 'spec/samples') }
+  let(:resolver) { described_class.new(base_path: base_path) }
 
   describe '#find' do
     subject { resolver.find(id) }
@@ -16,13 +18,13 @@ describe Riiif::FileSystemFileResolver do
     context 'when a jpeg2000 file is found' do
       let(:id) { 'world' }
       it 'returns the jpeg2000 file' do
-        expect(subject.path).to eq resolver.root + '/spec/samples/world.jp2'
+        expect(subject.path).to eq base_path + '/world.jp2'
       end
     end
   end
 
   describe '#input_types' do
-    subject { described_class.new.send(:input_types) }
+    subject { resolver.send(:input_types) }
 
     it 'includes jp2 extension' do
       expect(subject).to include 'jp2'

--- a/spec/models/riiif/image_spec.rb
+++ b/spec/models/riiif/image_spec.rb
@@ -3,8 +3,15 @@ require 'spec_helper'
 RSpec.describe Riiif::Image do
   subject(:image) { described_class.new('world') }
 
-  before { Riiif::Image.cache.clear }
+  let(:root) { File.expand_path(::File.join(::File.dirname(__FILE__), '../../..')) }
+  let(:base_path) { ::File.join(root, 'spec/samples') }
+  let(:resolver) { Riiif::FileSystemFileResolver.new(base_path: base_path) }
   let(:filename) { File.expand_path('spec/samples/world.jp2') }
+
+  before do
+    described_class.file_resolver = resolver
+    Riiif::Image.cache.clear
+  end
 
   describe 'happy path' do
     before do
@@ -43,7 +50,7 @@ RSpec.describe Riiif::Image do
       end
     end
     after do
-      described_class.file_resolver = Riiif::FileSystemFileResolver.new
+      described_class.file_resolver = resolver
     end
 
     describe 'get info' do


### PR DESCRIPTION
The current default doesn't make sense outside of the testing context