### PR TITLE
lib/riiif: autoload Riiif::Image class

### DIFF
--- a/lib/riiif.rb
+++ b/lib/riiif.rb
@@ -1,8 +1,10 @@
 require 'riiif/version'
 require 'deprecation'
 require 'riiif/engine'
+
 module Riiif
   extend ActiveSupport::Autoload
+  autoload :Image
   autoload :Routes
 
   class Error < RuntimeError; end


### PR DESCRIPTION
Removed in
https://github.com/curationexperts/riiif/commit/f1556340091ea008cd1cb46cce82287d80b74874,
but this can cause init errors of the 'undefined method `file_resolver=' for
Riiif::Image:Class (NoMethodError)' variety.

cc @jcoyne