### PR TITLE
ImageMagickCommandFactory: only extract first layer for PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,14 @@ Riiif::Image.info_service = lambda do |id, file|
   resp = ActiveFedora::SolrService.get("id:#{fs_id}")
   doc = resp['response']['docs'].first
   raise "Unable to find solr document with id:#{fs_id}" unless doc
-  { height: doc['height_is'], width: doc['width_is'] }
+
+  # You’ll want default values if you make thumbnails of PDFs or other
+  # file types that `identify` won’t return dimensions for
+  {
+    height: doc["height_is"] || 100,
+    width: doc["width_is"] || 100,
+    format: doc["mime_type_ssi"],
+  }
 end
 
 def logger

--- a/app/models/riiif/image.rb
+++ b/app/models/riiif/image.rb
@@ -51,7 +51,11 @@ module Riiif
     def info
       @info ||= begin
                   result = info_service.call(id, file)
-                  ImageInformation.new(width: result[:width], height: result[:height])
+                  ImageInformation.new(
+                    width: result[:width],
+                    height: result[:height],
+                    format: result[:format]
+                  )
                 end
     end
 

--- a/app/models/riiif/image_information.rb
+++ b/app/models/riiif/image_information.rb
@@ -5,15 +5,18 @@ module Riiif
 
     def initialize(*args)
       if args.size == 2
-        Deprecation.warn(self, 'calling initialize without kwargs is deprecated. Use height: and width:')
+        Deprecation.warn(self, 'calling initialize without kwargs is deprecated. Use named parameters.')
         super(width: args.first, height: args.second)
       else
-        super
+        @width = args.first[:width]
+        @height = args.first[:height]
+        @format = args.first[:format]
       end
     end
+    attr_reader :format, :height, :width
 
     def to_h
-      { width: width, height: height }
+      { width: width, height: height, format: format }
     end
 
     # Image information is only valid if height and width are present.

--- a/app/services/riiif/image_magick_info_extractor.rb
+++ b/app/services/riiif/image_magick_info_extractor.rb
@@ -10,8 +10,15 @@ module Riiif
     end
 
     def extract
-      height, width = Riiif::CommandRunner.execute("#{external_command} -format %hx%w #{@path}[0]").split('x')
-      { height: Integer(height), width: Integer(width) }
+      height, width, format = Riiif::CommandRunner.execute(
+        "#{external_command} -format '%h %w %m' #{@path}[0]"
+      ).split(' ')
+
+      {
+        height: Integer(height),
+        width: Integer(width),
+        format: format
+      }
     end
   end
 end

--- a/app/services/riiif/imagemagick_command_factory.rb
+++ b/app/services/riiif/imagemagick_command_factory.rb
@@ -44,8 +44,12 @@ module Riiif
         transformation.format == 'jpg'.freeze
       end
 
+      def layer_spec
+        '[0]' if info.format =~ /pdf/i
+      end
+
       def input
-        " #{path}"
+        " #{path}#{layer_spec}"
       end
 
       # pipe the output to STDOUT

--- a/spec/controllers/riiif/images_controller_spec.rb
+++ b/spec/controllers/riiif/images_controller_spec.rb
@@ -138,7 +138,9 @@ RSpec.describe Riiif::ImagesController do
 
       before do
         allow(Riiif::Image).to receive(:new).with('abcd1234').and_return(image)
-        allow(image).to receive(:info).and_return(Riiif::ImageInformation.new(width: 6000, height: 4000))
+        allow(image).to(
+          receive(:info).and_return(Riiif::ImageInformation.new(width: 6000, height: 4000, format: 'JPEG'))
+        )
       end
 
       it 'returns info' do
@@ -148,6 +150,7 @@ RSpec.describe Riiif::ImagesController do
                            '@id' => 'http://test.host/abcd1234',
                            'width' => 6000,
                            'height' => 4000,
+                           'format' => 'JPEG',
                            'profile' => ['http://iiif.io/api/image/2/level1.json', 'formats' => %w(jpg png)],
                            'protocol' => 'http://iiif.io/api/image'
         expect(response.headers['Link']).to eq '<http://iiif.io/api/image/2/level1.json>;rel="profile"'

--- a/spec/models/riiif/image_spec.rb
+++ b/spec/models/riiif/image_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Riiif::Image do
   describe '#render' do
     before do
       allow(Riiif::CommandRunner).to receive(:execute)
-        .with("identify -format %hx%w #{filename}[0]").and_return('131x175')
+        .with("identify -format '%h %w %m' #{filename}[0]").and_return('131 175 JPEG')
     end
 
     describe 'region' do

--- a/spec/services/riiif/imagemagick_command_factory_spec.rb
+++ b/spec/services/riiif/imagemagick_command_factory_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Riiif::ImagemagickCommandFactory do
   let(:path) { 'foo.tiff' }
-  let(:info) { double('foo') }
+  let(:info) { double(height: 100, width: 100, format: 'JPEG') }
 
   describe '.command' do
     subject { instance.command }


### PR DESCRIPTION
Should fix black images; see https://github.com/samvera/hydra-derivatives/issues/110 and https://github.com/samvera/hydra-derivatives/pull/120