### PR TITLE
Refer to File in root namespace

### DIFF
--- a/app/models/riiif/image.rb
+++ b/app/models/riiif/image.rb
@@ -5,7 +5,7 @@ module Riiif
     extend Deprecation
 
     class_attribute :file_resolver, :info_service, :authorization_service, :cache
-    self.file_resolver = FileSystemFileResolver.new(base_path: File.join(Rails.root, 'tmp'))
+    self.file_resolver = FileSystemFileResolver.new(base_path: ::File.join(Rails.root, 'tmp'))
     self.authorization_service = NilAuthorizationService
     self.cache = Rails.cache
 


### PR DESCRIPTION
When running a rails console in my production environment I got the following error:

```
/usr/local/bundle/gems/riiif-1.7.0/app/models/riiif/image.rb:24:in `<class:Image>': undefined method `join' for Riiif::File:Class (NoMethodError)
	from /usr/local/bundle/gems/riiif-1.7.0/app/models/riiif/image.rb:20:in `<module:Riiif>'
	from /usr/local/bundle/gems/riiif-1.7.0/app/models/riiif/image.rb:19:in `<top (required)>'
	from /usr/local/bundle/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:476:in `load'
	from /usr/local/bundle/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:476:in `block in load_file'
	from /usr/local/bundle/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:661:in `new_constants_in'
	from /usr/local/bundle/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:475:in `load_file'
	from /usr/local/bundle/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:374:in `block in require_or_load'
	from /usr/local/bundle/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:36:in `block in load_interlock'
	from /usr/local/bundle/gems/activesupport-5.1.4/lib/active_support/dependencies/interlock.rb:12:in `block in loading'
	from /usr/local/bundle/gems/activesupport-5.1.4/lib/active_support/concurrency/share_lock.rb:149:in `exclusive'
	from /usr/local/bundle/gems/activesupport-5.1.4/lib/active_support/dependencies/interlock.rb:11:in `loading'
	from /usr/local/bundle/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:36:in `load_interlock'
	from /usr/local/bundle/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:357:in `require_or_load'
	from /usr/local/bundle/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:335:in `depend_on'
	from /usr/local/bundle/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:251:in `require_dependency'
	from /usr/local/bundle/gems/railties-5.1.4/lib/rails/engine.rb:476:in `block (2 levels) in eager_load!'
	from /usr/local/bundle/gems/railties-5.1.4/lib/rails/engine.rb:475:in `each'
	from /usr/local/bundle/gems/railties-5.1.4/lib/rails/engine.rb:475:in `block in eager_load!'
	from /usr/local/bundle/gems/railties-5.1.4/lib/rails/engine.rb:473:in `each'
	from /usr/local/bundle/gems/railties-5.1.4/lib/rails/engine.rb:473:in `eager_load!'
	from /usr/local/bundle/gems/railties-5.1.4/lib/rails/engine.rb:354:in `eager_load!'
	from /usr/local/bundle/gems/railties-5.1.4/lib/rails/application/finisher.rb:67:in `each'
	from /usr/local/bundle/gems/railties-5.1.4/lib/rails/application/finisher.rb:67:in `block in <module:Finisher>'
	from /usr/local/bundle/gems/railties-5.1.4/lib/rails/initializable.rb:30:in `instance_exec'
	from /usr/local/bundle/gems/railties-5.1.4/lib/rails/initializable.rb:30:in `run'
	from /usr/local/bundle/gems/railties-5.1.4/lib/rails/initializable.rb:59:in `block in run_initializers'
	from /usr/local/lib/ruby/2.5.0/tsort.rb:228:in `block in tsort_each'
	from /usr/local/lib/ruby/2.5.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /usr/local/lib/ruby/2.5.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /usr/local/lib/ruby/2.5.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /usr/local/lib/ruby/2.5.0/tsort.rb:347:in `each'
	from /usr/local/lib/ruby/2.5.0/tsort.rb:347:in `call'
	from /usr/local/lib/ruby/2.5.0/tsort.rb:347:in `each_strongly_connected_component'
	from /usr/local/lib/ruby/2.5.0/tsort.rb:226:in `tsort_each'
	from /usr/local/lib/ruby/2.5.0/tsort.rb:205:in `tsort_each'
	from /usr/local/bundle/gems/railties-5.1.4/lib/rails/initializable.rb:58:in `run_initializers'
	from /usr/local/bundle/gems/railties-5.1.4/lib/rails/application.rb:353:in `initialize!'
	from /usr/src/app/config/environment.rb:5:in `<top (required)>'
	from /usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:102:in `require'
	from /usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:102:in `preload'
	from /usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:153:in `serve'
	from /usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:141:in `block in run'
	from /usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:135:in `loop'
	from /usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:135:in `run'
	from /usr/local/bundle/gems/spring-2.0.2/lib/spring/application/boot.rb:19:in `<top (required)>'
	from /usr/local/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	from /usr/local/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	from -e:1:in `<main>'
```

This is because Riiif::File does not contain a join-method. Changed line forces the use of File in the root namespace. Was not able to reproduce this anywhere else.