### PR TITLE
ImageMagick: remove alpha channel from PDF thumbnails

### DIFF
--- a/app/services/riiif/imagemagick_command_factory.rb
+++ b/app/services/riiif/imagemagick_command_factory.rb
@@ -27,7 +27,19 @@ module Riiif
 
     # @return [String] a command for running imagemagick to produce the requested output
     def command
-      [external_command, crop, size, rotation, colorspace, quality, sampling, metadata, input, output].join
+      [
+        external_command,
+        crop,
+        size,
+        rotation,
+        colorspace,
+        quality,
+        sampling,
+        metadata,
+        alpha_channel,
+        input,
+        output
+      ].join
     end
 
     def reduction_factor
@@ -82,6 +94,10 @@ module Riiif
 
       def sampling
         " -sampling-factor #{sampling_factor}" if jpeg?
+      end
+
+      def alpha_channel
+        ' -alpha remove' if info.format =~ /pdf/i
       end
 
       def colorspace

--- a/riiif.gemspec
+++ b/riiif.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'railties', '>= 4.2', '<6'
   spec.add_dependency 'deprecation', '>= 1.0.0'
   spec.add_dependency 'iiif-image-api', '~> 0.1.0'
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'engine_cart', '~> 2.0'
   spec.add_development_dependency 'rspec-rails'

--- a/spec/services/riiif/imagemagick_command_factory_spec.rb
+++ b/spec/services/riiif/imagemagick_command_factory_spec.rb
@@ -1,33 +1,50 @@
 require 'spec_helper'
 
 RSpec.describe Riiif::ImagemagickCommandFactory do
-  let(:path) { 'foo.tiff' }
-  let(:info) { double(height: 100, width: 100, format: 'JPEG') }
+  let(:tiff) { 'foo.tiff' }
+  let(:pdf) { 'faa.pdf' }
+  let(:info) { double(height: 100, width: 100, format: source) }
 
   describe '.command' do
-    subject { instance.command }
-    let(:instance) { described_class.new(path, info, transformation) }
-
     let(:transformation) do
       IIIF::Image::Transformation.new(region: IIIF::Image::Region::Full.new,
                                       size: IIIF::Image::Size::Full.new,
                                       quality: 'quality',
                                       rotation: 15.2,
-                                      format: format)
+                                      format: target)
     end
 
-    context "when it's a jpeg" do
-      let(:format) { 'jpg' }
+    context "when the target format is jpeg" do
+      subject { described_class.new(tiff, info, transformation).command }
+
+      let(:source) { 'tif' }
+      let(:target) { 'jpg' }
+
       it { is_expected.to match(/-quality 85/) }
     end
 
-    context "when it's a tiff" do
-      let(:format) { 'tif' }
+    context "when the target format is tiff" do
+      subject { described_class.new(tiff, info, transformation).command }
+
+      let(:source) { 'tif' }
+      let(:target) { 'tif' }
+
       it { is_expected.not_to match(/-quality/) }
     end
 
+    context "when when the source format is pdf" do
+      subject { described_class.new(pdf, info, transformation).command }
+      let(:source) { 'pdf' }
+      let(:target) { 'jpg' }
+
+      it { is_expected.to match(/-alpha\ remove/) }
+    end
+
     describe '#external_command' do
-      let(:format) { 'jpg' }
+      subject { described_class.new(tiff, info, transformation).command }
+      let(:source) { 'tif' }
+      let(:target) { 'jpg' }
+
       around do |example|
         orig = described_class.external_command
         described_class.external_command = 'gm convert'


### PR DESCRIPTION
Will otherwise create black images in most cases.