### PR TITLE
Remove alpha channel from PNG

### DIFF
--- a/app/models/riiif/image.rb
+++ b/app/models/riiif/image.rb
@@ -54,7 +54,8 @@ module Riiif
                   ImageInformation.new(
                     width: result[:width],
                     height: result[:height],
-                    format: result[:format]
+                    format: result[:format],
+                    channels: result[:channels]
                   )
                 end
     end

--- a/app/models/riiif/image_information.rb
+++ b/app/models/riiif/image_information.rb
@@ -11,12 +11,13 @@ module Riiif
         @width = args.first[:width]
         @height = args.first[:height]
         @format = args.first[:format]
+        @channels = args.first[:channels]
       end
     end
-    attr_reader :format, :height, :width
+    attr_reader :format, :height, :width, :channels
 
     def to_h
-      { width: width, height: height, format: format }
+      { width: width, height: height, format: format, channels: channels }
     end
 
     # Image information is only valid if height and width are present.

--- a/app/services/riiif/image_magick_info_extractor.rb
+++ b/app/services/riiif/image_magick_info_extractor.rb
@@ -1,5 +1,5 @@
 module Riiif
-  # Get height and width information using imagemagick to interrogate the file
+  # Get information using imagemagick to interrogate the file
   class ImageMagickInfoExtractor
     # perhaps you want to use GraphicsMagick instead, set to "gm identify"
     class_attribute :external_command
@@ -10,14 +10,15 @@ module Riiif
     end
 
     def extract
-      height, width, format = Riiif::CommandRunner.execute(
-        "#{external_command} -format '%h %w %m' #{@path}[0]"
+      height, width, format, channels = Riiif::CommandRunner.execute(
+        "#{external_command} -format '%h %w %m %[channels]' #{@path}[0]"
       ).split(' ')
 
       {
         height: Integer(height),
         width: Integer(width),
-        format: format
+        format: format,
+        channels: channels
       }
     end
   end

--- a/spec/controllers/riiif/images_controller_spec.rb
+++ b/spec/controllers/riiif/images_controller_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Riiif::ImagesController do
       before do
         allow(Riiif::Image).to receive(:new).with('abcd1234').and_return(image)
         allow(image).to(
-          receive(:info).and_return(Riiif::ImageInformation.new(width: 6000, height: 4000, format: 'JPEG'))
+          receive(:info).and_return(Riiif::ImageInformation.new(width: 6000, height: 4000, format: 'JPEG', channels: 'rgb'))
         )
       end
 
@@ -159,6 +159,7 @@ RSpec.describe Riiif::ImagesController do
                            'width' => 6000,
                            'height' => 4000,
                            'format' => 'JPEG',
+                           'channels' => 'rgb',
                            'profile' => ['http://iiif.io/api/image/2/level1.json', 'formats' => %w(jpg png)],
                            'protocol' => 'http://iiif.io/api/image'
         expect(response.headers['Link']).to eq '<http://iiif.io/api/image/2/level1.json>;rel="profile"'

--- a/spec/models/riiif/image_spec.rb
+++ b/spec/models/riiif/image_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Riiif::Image do
   describe '#render' do
     before do
       allow(Riiif::CommandRunner).to receive(:execute)
-        .with("identify -format '%h %w %m' #{filename}[0]").and_return('131 175 JPEG')
+        .with("identify -format '%h %w %m %[channels]' #{filename}[0]").and_return('131 175 JPEG')
     end
 
     describe 'region' do

--- a/spec/services/riiif/imagemagick_command_factory_spec.rb
+++ b/spec/services/riiif/imagemagick_command_factory_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 RSpec.describe Riiif::ImagemagickCommandFactory do
   let(:tiff) { 'foo.tiff' }
   let(:pdf) { 'faa.pdf' }
-  let(:info) { double(height: 100, width: 100, format: source) }
+  let(:png) { 'laa.png' }
+  let(:channels) { 'rgb' }
+  let(:info) { double(height: 100, width: 100, format: source, channels: channels) }
 
   describe '.command' do
     let(:transformation) do
@@ -32,12 +34,39 @@ RSpec.describe Riiif::ImagemagickCommandFactory do
       it { is_expected.not_to match(/-quality/) }
     end
 
-    context "when when the source format is pdf" do
+    context "when the source format is pdf" do
       subject { described_class.new(pdf, info, transformation).command }
       let(:source) { 'pdf' }
       let(:target) { 'jpg' }
 
       it { is_expected.to match(/-alpha\ remove/) }
+    end
+
+    context "when the source and target format is png" do
+      subject { described_class.new(png, info, transformation).command }
+      let(:source) { 'png' }
+      let(:target) { 'png' }
+
+      it { is_expected.to match(/png:-/) }
+    end
+
+    context "when the source format is png, the png has an alpha channel and the target format is png" do
+      subject { described_class.new(png, info, transformation).command }
+      let(:source) { 'png' }
+      let(:target) { 'png' }
+      let(:channels) { 'rgba' }
+
+      it { is_expected.to match(/alpha on/) }
+    end
+
+    context "when the source format is png, the png has an alpha channel and the target format is jpg" do
+      subject { described_class.new(png, info, transformation).command }
+      let(:source) { 'png' }
+      let(:target) { 'jpg' }
+      let(:channels) { 'rgba' }
+
+      it { is_expected.to match(/alpha on/) }
+      it { is_expected.to match(/png:-/) }
     end
 
     describe '#external_command' do


### PR DESCRIPTION
Fixes #124 

As reported in [hyrax#3422](https://github.com/samvera/hyrax/issues/3422). 

The solution to the immediate Hyrax issue woule be to request png as the transformation format where the source was png (and had an alpha channel). But ... Universal Viewer seems to ignore the format set in the manifest and requests jpg anyway. 

So, to ensure we retain the alpha channel, this PR now does the following:

1) checks for the existentence of an alpha channel (using the info_service output)
2) if there is an alpha channel, add the `-alpha on` flag to the convert command to ensure it is retained
3) override the transformation format to be png where there is an alpha channel and the transformation format is jpg (since jpg can't support this)

The obvious problem here is that we could be (and would be in the case of Universal Viewer requests) returning a different format to that requested, however UV seems to be already doing the same.

There will be a companion Hyrax PR to add 'channels' to the info_service output.