### PR TITLE
WIP: teach RIIIF how to handle external IIIF servers

### DIFF
--- a/app/controllers/riiif/images_controller.rb
+++ b/app/controllers/riiif/images_controller.rb
@@ -111,7 +111,7 @@ module Riiif
                 "Riiif.#{err}_image is not configured; assign it to an image path in your RIIIF initializer"
         end
 
-        model.new(image_id, Riiif::File.new(image))
+        model.new(image_id, Riiif::File.new(path: image))
       end
 
       CONTEXT = '@context'.freeze

--- a/app/models/riiif/external_file.rb
+++ b/app/models/riiif/external_file.rb
@@ -1,0 +1,20 @@
+module Riiif
+  class ExternalFile < ::Riiif::File
+    attr_reader :path, :id
+
+    # @param path [String] The location of an image file
+    # @param id [String] the ID of the image
+    def initialize(path:, id:)
+      @path = path
+      @id = id
+    end
+
+    def transformer
+      ExternalFileTransformer
+    end
+
+    def info_extractor
+      @info_extractor ||= ExternalInfoExtractor.new(path: path, id: id)
+    end
+  end
+end

--- a/app/models/riiif/file.rb
+++ b/app/models/riiif/file.rb
@@ -1,22 +1,26 @@
 module Riiif
   class File
-    attr_reader :path
+    attr_reader :path, :id
 
     class_attribute :info_extractor_class
     # TODO: add alternative that uses kdu_jp2info
     self.info_extractor_class = ImageMagickInfoExtractor
 
-    # @param input_path [String] The location of an image file
-    def initialize(input_path, tempfile = nil)
-      @path = input_path
-      @tempfile = tempfile # ensures that the tempfile will stick around until this file is garbage collected.
+    # @param path [String] The location of an image file
+    # @param id [String] the ID of the image
+    def initialize(path: nil, id: nil)
+      @path = path
+      @id = id
     end
 
-    # @param [Transformation] transformation
+    # @param [IIIF::Image::Transformation] transformation
     # @param [ImageInformation] image_info
     # @return [String] the processed image data
-    def extract(transformation, image_info = info)
-      transformer.transform(path, image_info, transformation)
+    def extract(transformation:, image_info:)
+      transformer.transform(path: path,
+                            image_info: image_info,
+                            transformation: transformation,
+                            id: id)
     end
 
     def transformer
@@ -27,12 +31,13 @@ module Riiif
       end
     end
 
+    # @return [Hash]
     def info
       @info ||= info_extractor.extract
     end
 
     def info_extractor
-      @info_extractor ||= info_extractor_class.new(path)
+      @info_extractor ||= info_extractor_class.new(path: path, id: id)
     end
   end
 end

--- a/app/models/riiif/file.rb
+++ b/app/models/riiif/file.rb
@@ -16,7 +16,7 @@ module Riiif
     # @param [IIIF::Image::Transformation] transformation
     # @param [ImageInformation] image_info
     # @return [String] the processed image data
-    def extract(transformation:, image_info:)
+    def extract(transformation:, image_info: nil)
       transformer.transform(path: path,
                             image_info: image_info,
                             transformation: transformation,

--- a/app/resolvers/riiif/abstract_file_system_resolver.rb
+++ b/app/resolvers/riiif/abstract_file_system_resolver.rb
@@ -8,7 +8,7 @@ module Riiif
     end
 
     def find(id)
-      Riiif::File.new(path(id))
+      Riiif::File.new(path: path(id))
     end
 
     # @param [String] id the id to resolve

--- a/app/resolvers/riiif/external_file_resolver.rb
+++ b/app/resolvers/riiif/external_file_resolver.rb
@@ -1,0 +1,9 @@
+module Riiif
+  class ExternalFileResolver
+    def initialize; end
+
+    def find(id)
+      Riiif::ExternalFile.new(path: nil, id: id)
+    end
+  end
+end

--- a/app/resolvers/riiif/http_file_resolver.rb
+++ b/app/resolvers/riiif/http_file_resolver.rb
@@ -23,7 +23,7 @@ module Riiif
       remote = RemoteFile.new(uri(id),
                               cache_path: cache_path,
                               basic_auth_credentials: basic_auth_credentials)
-      Riiif::File.new(remote.fetch)
+      Riiif::File.new(path: remote.fetch)
     end
 
     class RemoteFile

--- a/app/services/riiif/external_info_extractor.rb
+++ b/app/services/riiif/external_info_extractor.rb
@@ -1,0 +1,19 @@
+require "net/http"
+
+module Riiif
+  # Get information about an image from an external IIIF server
+  class ExternalInfoExtractor
+    attr_reader :path, :id
+
+    def initialize(path:, id:)
+      @path = path
+      @id = id
+    end
+
+    def extract
+      uri = URI("#{ENV['IIIF_BASE_URL']}/#{id}/info.json")
+
+      JSON.parse(Net::HTTP.get_response(uri).body)
+    end
+  end
+end

--- a/app/services/riiif/image_magick_info_extractor.rb
+++ b/app/services/riiif/image_magick_info_extractor.rb
@@ -5,8 +5,9 @@ module Riiif
     class_attribute :external_command
     self.external_command = 'identify'
 
-    def initialize(path)
+    def initialize(path:, id:)
       @path = path
+      @id = id
     end
 
     def extract

--- a/app/transformers/riiif/abstract_fs_transformer.rb
+++ b/app/transformers/riiif/abstract_fs_transformer.rb
@@ -1,0 +1,15 @@
+module Riiif
+  # Transforms an image from the filesystem using a backend
+  class AbstractFsTransformer < AbstractTransformer
+    def transform
+      execute(command_builder.command)
+    end
+
+    def command_builder
+      @command_builder ||= command_factory.new(path, image_info, transformation)
+    end
+
+    delegate :execute, to: Riiif::CommandRunner
+    private :execute
+  end
+end

--- a/app/transformers/riiif/abstract_transformer.rb
+++ b/app/transformers/riiif/abstract_transformer.rb
@@ -1,30 +1,25 @@
 module Riiif
-  # Transforms an image using a backend
+  # Transforms and returns an image
   class AbstractTransformer
-    # @param path [String] The path of the source image file
+    # @param path [String] The path of the source image file (required only for filesystem-based transformers)
     # @param image_info [ImageInformation] information about the source
-    # @param [Transformation] transformation
-    def self.transform(path, image_info, transformation)
-      new(path, image_info, transformation).transform
+    # @param [IIIF::Image::Transformation] transformation
+    # @param [String] the Riiif::Image ID
+    def self.transform(path: nil, image_info:, transformation:, id: nil)
+      new(path: path, image_info: image_info, transformation: transformation, id: id).transform
     end
 
-    def initialize(path, image_info, transformation)
+    def initialize(path:, image_info:, transformation:, id: nil)
       @path = path
       @image_info = image_info
       @transformation = transformation
+      @id = id
     end
 
-    attr_reader :path, :image_info, :transformation
+    attr_reader :path, :image_info, :transformation, :id
 
     def transform
-      execute(command_builder.command)
+      raise NotImplementedError, "Implement #transform in the concrete class"
     end
-
-    def command_builder
-      @command_builder ||= command_factory.new(path, image_info, transformation)
-    end
-
-    delegate :execute, to: Riiif::CommandRunner
-    private :execute
   end
 end

--- a/app/transformers/riiif/external_file_transformer.rb
+++ b/app/transformers/riiif/external_file_transformer.rb
@@ -1,0 +1,21 @@
+module Riiif
+  # Transforms an image from the filesystem using a backend
+  class ExternalFileTransformer < AbstractTransformer
+    def transform
+      Net::HTTP.get_response(
+        URI(
+          "#{base_url}/" \
+          "#{id}/" \
+          "#{transformation.region}/" \
+          "#{transformation.size}/" \
+          "#{transformation.rotation}/" \
+          "#{transformation.quality}.#{transformation.format}"
+        )
+      ).body
+    end
+
+    def base_url
+      @base_url ||= ENV["IIIF_BASE_URL"]
+    end
+  end
+end

--- a/app/transformers/riiif/imagemagick_transformer.rb
+++ b/app/transformers/riiif/imagemagick_transformer.rb
@@ -1,6 +1,6 @@
 module Riiif
   # Transforms an image using Imagemagick
-  class ImagemagickTransformer < AbstractTransformer
+  class ImagemagickTransformer < AbstractFsTransformer
     def command_factory
       ImagemagickCommandFactory
     end

--- a/app/transformers/riiif/kakadu_transformer.rb
+++ b/app/transformers/riiif/kakadu_transformer.rb
@@ -1,6 +1,6 @@
 module Riiif
   # Transforms an image using Kakadu
-  class KakaduTransformer < AbstractTransformer
+  class KakaduTransformer < AbstractFsTransformer
     def command_factory
       KakaduCommandFactory
     end
@@ -27,7 +27,7 @@ module Riiif
                        else
                          without_crop
                        end
-      Riiif::File.new(intermediate_file).extract(transformation, image_info)
+      Riiif::File.new(path: intermediate_file).extract(transformation: transformation, image_info: image_info)
     end
 
     private

--- a/spec/models/riiif/akubra_system_file_resolver_spec.rb
+++ b/spec/models/riiif/akubra_system_file_resolver_spec.rb
@@ -8,6 +8,6 @@ describe Riiif::AkubraSystemFileResolver do
 
   it 'gets the jpeg2000 file' do
     file = Dir.glob(subject.pathroot + '22/7e/9/info%3Afedora%2Fdemo%3A1%2Fjp2%2Fjp2.0').first
-    expect(subject.find('demo:1').path).to eq Riiif::File.new(file).path
+    expect(subject.find('demo:1').path).to eq Riiif::File.new(path: file).path
   end
 end

--- a/spec/models/riiif/image_spec.rb
+++ b/spec/models/riiif/image_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Riiif::Image do
   end
 
   it 'is able to override the file used for the Image' do
-    img = described_class.new('some_id', Riiif::File.new(filename))
+    img = described_class.new('some_id', Riiif::File.new(path: filename))
     expect(img.id).to eq 'some_id'
     expect(img.info).to eq Riiif::ImageInformation.new(width: 800, height: 400)
   end

--- a/spec/transformers/riiif/kakadu_transformer_spec.rb
+++ b/spec/transformers/riiif/kakadu_transformer_spec.rb
@@ -3,7 +3,11 @@
 require 'spec_helper'
 
 RSpec.describe Riiif::KakaduTransformer do
-  subject(:instance) { described_class.new(path, image_info, transformation) }
+  subject(:instance) do
+    described_class.new(path: path,
+                        image_info: image_info,
+                        transformation: transformation)
+  end
 
   let(:image_info) { Riiif::ImageInformation.new(width: 6501, height: 4381) }
   let(:path) { 'baseball.jp2' }


### PR DESCRIPTION
This is an alternative approach to GH-129 that lets RIIIF handle images from external image servers.

Changed method signatures:
- `Riiif::File.new`
- `Riiif::File#extract`
- `Riiif::AbstractTransformer.new`
- `Riiif::AbstractTransformer.transform`
- `Riiif::ImageMagickInfoExtractor.new`

Remaining issues include errors when loading the manifest within Universal Viewer:
<img width="408" alt="Screen Shot 2019-11-08 at 1 20 06 PM" src="https://user-images.githubusercontent.com/985416/68511571-1eb13280-022b-11ea-9974-37673b12a50e.png">
