### PR TITLE
Fix Vips info extraction for metadata values with ": " included

### DIFF
--- a/app/extractors/riiif/vips_info_extractor.rb
+++ b/app/extractors/riiif/vips_info_extractor.rb
@@ -8,7 +8,7 @@ module Riiif
     def extract
       attributes = Riiif::CommandRunner.execute("#{external_command} '#{@path}' -a")
                                        .split(/\n/)
-                                       .map { |str| str.strip.split(': ') }.to_h
+                                       .map { |str| str.strip.split(': ', 2) }.to_h
       width, height = attributes.values_at("width", "height")
 
       {

--- a/spec/extractors/riiif/vips_info_extractor_spec.rb
+++ b/spec/extractors/riiif/vips_info_extractor_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe Riiif::VipsInfoExtractor do
 
     let(:fake_info) do
       "width: 50
-    height: 50
-    interpretation: srgb
-    filename: spec/fixtures/test.tif
-    vips-loader: pngload"
+      height: 50
+      interpretation: srgb
+      filename: spec/fixtures/test.tif
+      vips-loader: pngload"
     end
 
     it 'returns the extracted attributes' do
@@ -48,6 +48,28 @@ RSpec.describe Riiif::VipsInfoExtractor do
                                                          width: 50,
                                                          format: "PNG",
                                                          channels: "srgba"
+                                                       })
+    end
+  end
+
+  context 'on a JPEG file with extra EXIF metadata' do
+    let(:image) { double(has_alpha?: false) }
+
+    let(:fake_info) do
+      "width: 150
+      height: 150
+      interpretation: srgb
+      filename: spec/fixtures/test.jpeg
+      vips-loader: jpegload
+      exif-ifd0-Artist: University Library (Digital Object: Digital Media Group)"
+    end
+
+    it 'returns the extracted attributes' do
+      expect(described_class.new(image).extract).to eq({
+                                                         height: 150,
+                                                         width: 150,
+                                                         format: "JPEG",
+                                                         channels: "srgb"
                                                        })
     end
   end


### PR DESCRIPTION
When a Vips metadata value includes ": " (ex. for extra EXIF metadata), the extraction hits an error when trying to convert the attributes to a hash (ex. `in 'Array#to_h': wrong array length at 24 (expected 2, was 4) (ArgumentError)`). This fixes the bug and adds a test.