### PR TITLE
Update vipsheader command to retrieve only the fields required for extraction

### DIFF
--- a/app/extractors/riiif/vips_info_extractor.rb
+++ b/app/extractors/riiif/vips_info_extractor.rb
@@ -6,15 +6,14 @@ module Riiif
     self.external_command = 'vipsheader'
 
     def extract
-      attributes = Riiif::CommandRunner.execute("#{external_command} '#{@path}' -a")
-                                       .split(/\n/)
-                                       .map { |str| str.strip.split(': ', 2) }.to_h
-      width, height = attributes.values_at("width", "height")
+      width, height, vipsloader = Riiif::CommandRunner.execute(
+        "#{external_command} -f width -f height -f vips-loader '#{@path}'"
+      ).split(/\n/)
 
       {
         height: Integer(height),
         width: Integer(width),
-        format: attributes["vips-loader"].match?("pngload") ? "PNG" : "JPEG",
+        format: vipsloader.match?("pngload") ? "PNG" : "JPEG",
         channels: ::Vips::Image.new_from_file(@path.to_s).has_alpha? ? "srgba" : "srgb"
       }
     end

--- a/spec/extractors/riiif/vips_info_extractor_spec.rb
+++ b/spec/extractors/riiif/vips_info_extractor_spec.rb
@@ -9,11 +9,9 @@ RSpec.describe Riiif::VipsInfoExtractor do
   let(:image) { double(has_alpha?: false) }
 
   let(:fake_info) do
-    "width: 500
-    height: 376
-    interpretation: srgb
-    filename: spec/fixtures/test.tif
-    vips-loader: tiffload"
+    "500
+    376
+    tiffload"
   end
 
   it 'uses vipsheader as its external command' do
@@ -35,11 +33,9 @@ RSpec.describe Riiif::VipsInfoExtractor do
     let(:image) { double(has_alpha?: true) }
 
     let(:fake_info) do
-      "width: 50
-      height: 50
-      interpretation: srgb
-      filename: spec/fixtures/test.tif
-      vips-loader: pngload"
+      "50
+      50
+      pngload"
     end
 
     it 'returns the extracted attributes' do
@@ -48,28 +44,6 @@ RSpec.describe Riiif::VipsInfoExtractor do
                                                          width: 50,
                                                          format: "PNG",
                                                          channels: "srgba"
-                                                       })
-    end
-  end
-
-  context 'on a JPEG file with extra EXIF metadata' do
-    let(:image) { double(has_alpha?: false) }
-
-    let(:fake_info) do
-      "width: 150
-      height: 150
-      interpretation: srgb
-      filename: spec/fixtures/test.jpeg
-      vips-loader: jpegload
-      exif-ifd0-Artist: University Library (Digital Object: Digital Media Group)"
-    end
-
-    it 'returns the extracted attributes' do
-      expect(described_class.new(image).extract).to eq({
-                                                         height: 150,
-                                                         width: 150,
-                                                         format: "JPEG",
-                                                         channels: "srgb"
                                                        })
     end
   end


### PR DESCRIPTION
This is a follow-up to https://github.com/sul-dlss/riiif/pull/158. In addition to the error fixed in that PR, a different `'Array#to_h'` error occurs when `: ` is not present on every line of the vipsheader output. This is again due to messy EXIF data. 

This fix updates the command used, requesting only the basic information required for extraction and avoiding the need for additional processing.